### PR TITLE
Add FCH

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -682,7 +682,7 @@ index | hexa       | symbol | coin
 651   | 0x8000028b |        |
 652   | 0x8000028c |        |
 653   | 0x8000028d |        |
-654   | 0x8000028e |        |
+654   | 0x8000028e | FCH    | [FreeCash](https://www.freecash.org)
 655   | 0x8000028f |        |
 656   | 0x80000290 |        |
 657   | 0x80000291 |        |


### PR DESCRIPTION
Add FCH CoinType. Two Wallets has support FCH.
IfWallet(https://fir.im/ifwallet)  
Cryptosigner(https://download.sign.cash/Cryptosinger_v1.1.apk)